### PR TITLE
Switch depth camera to RGBD and align Gazebo bridge topics

### DIFF
--- a/bcr_arm_description/urdf/robots/bcr_arm.urdf
+++ b/bcr_arm_description/urdf/robots/bcr_arm.urdf
@@ -418,7 +418,7 @@
   <link name="camera_depth_optical_frame"/>
   <!-- Ignition Gazebo Camera Plugin -->
   <gazebo reference="camera_link">
-    <sensor name="depth_camera" type="camera">
+    <sensor name="depth_camera" type="rgbd_camera">
       <always_on>true</always_on>
       <update_rate>20</update_rate>
       <visualize>true</visualize>
@@ -428,10 +428,12 @@
           <width>640</width>
           <height>480</height>
           <format>R8G8B8</format>
+          <topic>/camera/color/image_raw</topic>
         </image>
         <depth_image>
           <width>640</width>
           <height>480</height>
+          <topic>/camera/depth/image_raw</topic>
         </depth_image>
         <clip>
           <near>0.1</near>

--- a/bcr_arm_description/urdf/sensors/depth_camera.urdf.xacro
+++ b/bcr_arm_description/urdf/sensors/depth_camera.urdf.xacro
@@ -48,9 +48,9 @@
 
     <link name="${prefix}camera_depth_optical_frame"/>
 
-    <!-- Ignition Gazebo Camera Plugin -->
+    <!-- Ignition Gazebo RGBD Camera Plugin -->
     <gazebo reference="${prefix}camera_link">
-      <sensor type="camera" name="depth_camera">
+      <sensor type="rgbd_camera" name="depth_camera">
         <always_on>true</always_on>
         <update_rate>20</update_rate>
         <visualize>true</visualize>
@@ -60,10 +60,12 @@
             <width>640</width>
             <height>480</height>
             <format>R8G8B8</format>
+            <topic>/camera/color/image_raw</topic>
           </image>
           <depth_image>
             <width>640</width>
             <height>480</height>
+            <topic>/camera/depth/image_raw</topic>
           </depth_image>
           <clip>
             <near>0.1</near>

--- a/bcr_arm_gazebo/launch/bringup.gazebo.launch.py
+++ b/bcr_arm_gazebo/launch/bringup.gazebo.launch.py
@@ -205,15 +205,10 @@ def generate_launch_description():
         package='ros_gz_image',
         executable='image_bridge',
         arguments=[
-            # Bridge the actual camera topics from Gazebo
-            '/camera/image_raw',
+            '/camera/color/image_raw',
             '/camera/depth/image_raw',
-            '/camera/camera_info',
+            '/camera/color/camera_info',
             '/camera/depth/camera_info',
-        ],
-        remappings=[
-            ('/camera/image_raw', '/camera/color/image_raw'),
-            ('/camera/camera_info', '/camera/color/camera_info'),
         ],
         output='screen',
         condition=IfCondition(use_camera)
@@ -223,10 +218,7 @@ def generate_launch_description():
     start_gazebo_ros_pointcloud_bridge_cmd = Node(
         package='ros_gz_point_cloud',
         executable='point_cloud_bridge',
-        arguments=['/camera/points'],
-        remappings=[
-            ('/camera/points', '/camera/depth/points'),
-        ],
+        arguments=['/camera/depth/points'],
         output='screen',
         condition=IfCondition(use_camera)
     )

--- a/bcr_arm_moveit_config/launch/bcr_arm_moveit_gazebo.launch.py
+++ b/bcr_arm_moveit_config/launch/bcr_arm_moveit_gazebo.launch.py
@@ -113,14 +113,10 @@ def generate_launch_description():
         package="ros_gz_image",
         executable="image_bridge",
         arguments=[
-            "/camera/image_raw",
+            "/camera/color/image_raw",
             "/camera/depth/image_raw",
-            "/camera/camera_info",
+            "/camera/color/camera_info",
             "/camera/depth/camera_info",
-        ],
-        remappings=[
-            ("/camera/image_raw", "/camera/color/image_raw"),
-            ("/camera/camera_info", "/camera/color/camera_info"),
         ],
         output="screen",
         condition=IfCondition(use_camera),
@@ -131,8 +127,7 @@ def generate_launch_description():
         point_cloud_bridge_node = Node(
             package="ros_gz_point_cloud",
             executable="point_cloud_bridge",
-            arguments=["/camera/points"],
-            remappings=[("/camera/points", "/camera/depth/points")],
+            arguments=["/camera/depth/points"],
             output="screen",
             condition=IfCondition(use_camera),
         )


### PR DESCRIPTION
## Summary
- use rgbd_camera sensor macro with explicit color and depth topics
- update image and point cloud bridge nodes to match new Gazebo topics

## Testing
- `colcon test --packages-select bcr_arm_description bcr_arm_moveit_config bcr_arm_gazebo` *(command not found)*
- `ros2 topic list` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a68deed1a88322bd79e7df71317992