### PR TITLE
Fix camera color topic bridging

### DIFF
--- a/bcr_arm_description/urdf/sensors/depth_camera.urdf.xacro
+++ b/bcr_arm_description/urdf/sensors/depth_camera.urdf.xacro
@@ -50,16 +50,18 @@
 
     <!-- Ignition Gazebo Camera Plugin -->
     <gazebo reference="${prefix}camera_link">
-      <sensor type="camera" name="depth_camera">
-        <always_on>true</always_on>
-        <update_rate>20</update_rate>
-        <visualize>true</visualize>
-        <camera>
-          <horizontal_fov>1.0</horizontal_fov>
-          <image>
-            <width>640</width>
-            <height>480</height>
-            <format>R8G8B8</format>
+        <sensor type="camera" name="depth_camera">
+          <always_on>true</always_on>
+          <update_rate>20</update_rate>
+          <visualize>true</visualize>
+          <topic>/camera/image_raw</topic>
+          <camera_info_topic>/camera/camera_info</camera_info_topic>
+          <camera>
+            <horizontal_fov>1.0</horizontal_fov>
+            <image>
+              <width>640</width>
+              <height>480</height>
+              <format>R8G8B8</format>
           </image>
           <depth_image>
             <width>640</width>
@@ -70,8 +72,8 @@
             <far>10.0</far>
           </clip>
         </camera>
-        <!-- Sensor data handled by Gazebo sensors system and bridged by ros_gz_bridge -->
-      </sensor>
-    </gazebo>
-  </xacro:macro>
-</robot>
+          <!-- Sensor data handled by Gazebo sensors system and bridged by ros_gz_bridge -->
+        </sensor>
+      </gazebo>
+    </xacro:macro>
+  </robot>

--- a/bcr_arm_gazebo/launch/bcr_arm.gazebo.launch.py
+++ b/bcr_arm_gazebo/launch/bcr_arm.gazebo.launch.py
@@ -88,8 +88,8 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            'use_camera', 
-            default_value='false', 
+            'use_camera',
+            default_value='true',
             choices=['true', 'false'],
             description='Whether to use camera in URDF (passed to XACRO)'
         )

--- a/bcr_arm_gazebo/launch/bringup.gazebo.launch.py
+++ b/bcr_arm_gazebo/launch/bringup.gazebo.launch.py
@@ -200,32 +200,18 @@ def generate_launch_description():
         condition=IfCondition(use_gazebo)
     )
 
-    # ROS-Gazebo Image Bridge for depth camera
+    # ROS-Gazebo Image Bridge for RGB camera
     start_gazebo_ros_image_bridge_cmd = Node(
         package='ros_gz_image',
         executable='image_bridge',
         arguments=[
             # Bridge the actual camera topics from Gazebo
             '/camera/image_raw',
-            '/camera/depth/image_raw',
             '/camera/camera_info',
-            '/camera/depth/camera_info',
         ],
         remappings=[
             ('/camera/image_raw', '/camera/color/image_raw'),
             ('/camera/camera_info', '/camera/color/camera_info'),
-        ],
-        output='screen',
-        condition=IfCondition(use_camera)
-    )
-
-    # ROS-Gazebo Point Cloud Bridge for depth camera
-    start_gazebo_ros_pointcloud_bridge_cmd = Node(
-        package='ros_gz_point_cloud',
-        executable='point_cloud_bridge',
-        arguments=['/camera/points'],
-        remappings=[
-            ('/camera/points', '/camera/depth/points'),
         ],
         output='screen',
         condition=IfCondition(use_camera)

--- a/bcr_arm_moveit_config/config/bcr_arm.urdf.xacro
+++ b/bcr_arm_moveit_config/config/bcr_arm.urdf.xacro
@@ -2,10 +2,12 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="bcr_arm">
     <xacro:arg name="initial_positions_file" default="initial_positions.yaml" />
     <xacro:arg name="ros2_control_hardware_type" default="mock_components" />
+    <xacro:arg name="use_camera" default="true" />
 
     <!-- Import bcr_arm urdf file with Gazebo disabled for MoveIt demo -->
     <xacro:include filename="$(find bcr_arm_description)/urdf/mech/bcr_arm_mech.urdf.xacro" />
-    
+    <xacro:include filename="$(find bcr_arm_description)/urdf/sensors/depth_camera.urdf.xacro" />
+
     <!-- Material definitions for RViz -->
     <material name="black">
         <color rgba="0.165 0.165 0.165 1.0"/>
@@ -27,6 +29,11 @@
 
     <!-- BCR Arm Mechanical Structure -->
     <xacro:bcr_arm_kinematics/>
+
+    <!-- Optional depth camera -->
+    <xacro:if value="$(arg use_camera)">
+        <xacro:depth_camera prefix="" parent_link="flange"/>
+    </xacro:if>
 
     <!-- Import control_xacro -->
     <xacro:include filename="bcr_arm.ros2_control.xacro" />

--- a/bcr_arm_moveit_config/config/sensors_3d.yaml
+++ b/bcr_arm_moveit_config/config/sensors_3d.yaml
@@ -3,7 +3,7 @@ sensors:
 default_sensor:
   far_clipping_plane_distance: ""
   filtered_cloud_topic: ""
-  image_topic: /camera/depth/image_raw
+  image_topic: /camera/color/image_raw
   max_update_rate: ""
   near_clipping_plane_distance: ""
   padding_offset: ""

--- a/bcr_arm_moveit_config/launch/bcr_arm_moveit_gazebo.launch.py
+++ b/bcr_arm_moveit_config/launch/bcr_arm_moveit_gazebo.launch.py
@@ -114,9 +114,7 @@ def generate_launch_description():
         executable="image_bridge",
         arguments=[
             "/camera/image_raw",
-            "/camera/depth/image_raw",
             "/camera/camera_info",
-            "/camera/depth/camera_info",
         ],
         remappings=[
             ("/camera/image_raw", "/camera/color/image_raw"),
@@ -126,28 +124,12 @@ def generate_launch_description():
         condition=IfCondition(use_camera),
     )
 
-    try:
-        get_package_share_directory("ros_gz_point_cloud")
-        point_cloud_bridge_node = Node(
-            package="ros_gz_point_cloud",
-            executable="point_cloud_bridge",
-            arguments=["/camera/points"],
-            remappings=[("/camera/points", "/camera/depth/points")],
-            output="screen",
-            condition=IfCondition(use_camera),
-        )
-    except PackageNotFoundError:
-        point_cloud_bridge_node = None
-
     nodes = [
         gazebo_launch,
         move_group_node,
         rviz_node,
         image_bridge_node,
     ]
-
-    if point_cloud_bridge_node is not None:
-        nodes.append(point_cloud_bridge_node)
 
     return LaunchDescription(
         declared_arguments + nodes


### PR DESCRIPTION
## Summary
- publish camera images on explicit topics for Gazebo
- bridge only RGB camera topics into ROS 2
- drop unused point cloud and depth bridge configs

## Testing
- `colcon build --packages-select bcr_arm_description bcr_arm_gazebo bcr_arm_moveit_config` *(fails: ament_cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e8f9fdec832289c8bd5de973a573