### PR TITLE
Fix image bridge topics for camera

### DIFF
--- a/bcr_arm_gazebo/launch/bringup.gazebo.launch.py
+++ b/bcr_arm_gazebo/launch/bringup.gazebo.launch.py
@@ -206,14 +206,16 @@ def generate_launch_description():
         executable='image_bridge',
         arguments=[
             # Bridge the actual camera topics from Gazebo
-            '/camera/image_raw',
-            '/camera/depth/image_raw',
+            '/camera/image',
+            '/camera/depth_image',
             '/camera/camera_info',
-            '/camera/depth/camera_info',
+            '/camera/depth_image_info',
         ],
         remappings=[
-            ('/camera/image_raw', '/camera/color/image_raw'),
+            ('/camera/image', '/camera/color/image_raw'),
             ('/camera/camera_info', '/camera/color/camera_info'),
+            ('/camera/depth_image', '/camera/depth/image_raw'),
+            ('/camera/depth_image_info', '/camera/depth/camera_info'),
         ],
         output='screen',
         condition=IfCondition(use_camera)


### PR DESCRIPTION
## Summary
- align ros_gz_image bridge topics with Gazebo sensor
- keep ROS-side remappings for legacy camera topics

## Testing
- `colcon build --merge-install --packages-select bcr_arm_description bcr_arm_gazebo --parallel-workers 2` *(fails: could not find ament_cmake)*
- `ros2 topic list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abd0ebc32883228562ab2258693b0f